### PR TITLE
Introduce loongarch32 target triple and __loongarch_ilp32

### DIFF
--- a/la-softdev-convention.adoc
+++ b/la-softdev-convention.adoc
@@ -114,8 +114,9 @@ link:https://github.com/loongson/LoongArch-Documentation/blob/main/docs/LoongArc
 | `\\__loongarch__`         | `1`                                           | Target architecture is LoongArch                                                                                                                                                          
 | `__loongarch_grlen`        | `64` `32`                                     | Bit-width of GPR                                                                                                                                                                          
 | `__loongarch_frlen`        | `0` `32` `64`                                 | Bit-width of FPR (`0` if no FPU)                                                                                                                                                          
-| `__loongarch_arch`         | `"loongarch64"` `"la464"` `"la64v1.0"` `"la64v1.1"`  | Target CPU name specified by `-march`. If not specified, defaults to the compiler-defined default. If `-march=native` is specified, then it is automatically detected by the compiler
-| `__loongarch_tune`         | `"loongarch64"` `"la464"`                     | Target CPU name specified by `-mtune`. If not specified, it defaults to the same as `__loongarch_arch`. If `-mtune=native` is specified, then it is automatically detected by the compiler
+| `__loongarch_arch`         | `"loongarch32"` `"loongarch32r"` `"loongarch64"` `"la464"` `"la64v1.0"` `"la64v1.1"`  | Target CPU name specified by `-march`. If not specified, defaults to the compiler-defined default. If `-march=native` is specified, then it is automatically detected by the compiler
+| `__loongarch_tune`         | `"loongarch32"` `"loongarch64"` `"la464"`                     | Target CPU name specified by `-mtune`. If not specified, it defaults to the same as `__loongarch_arch`. If `-mtune=native` is specified, then it is automatically detected by the compiler
+| `__loongarch_ilp32`        | Undefined or  `1`                             | ABI uses 32-bit GPR for parameter passing and follows ILP32 data model  
 | `__loongarch_lp64`         | Undefined or  `1`                             | ABI uses 64-bit GPR for parameter passing and follows LP64 data model                                                                                                                     
 | `__loongarch_hard_float`   | Undefined or `1`                              | ABI uses FPR for parameter passing                                                                                                                                                        
 | `__loongarch_soft_float`   | Undefined or  `1`                             | ABI does not use FPR for parameter passing                                                                                                                                                
@@ -128,6 +129,9 @@ link:https://github.com/loongson/LoongArch-Documentation/blob/main/docs/LoongArc
 [options="header"]
 |======================================================================
 | ABI Type        | C Library | Kernel      | Multiarch Identifier     
+| ilp32d / base   | glibc     | Linux       | loongarch32-linux-gnu
+| ilp32f / base   | glibc     | Linux       | loongarch32-linux-gnuf32
+| ilp32s / base   | glibc     | Linux       | loongarch32-linux-gnusf
 | lp64d / base    | glibc     | Linux       | loongarch64-linux-gnu    
 | lp64f / base    | glibc     | Linux       | loongarch64-linux-gnuf32 
 | lp64s / base    | glibc     | Linux       | loongarch64-linux-gnusf


### PR DESCRIPTION
Introduce loongarch32 target triples with the same format as loongarch64, but with ilp32[d|f|s] abi. `__loongarch_ilp32` macro is added.